### PR TITLE
build: add build info on compile time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24.1 AS setup
+FROM golang:1.24.2 AS setup
 
 WORKDIR /app
 
@@ -11,10 +11,16 @@ COPY . .
 
 FROM setup AS builder
 
-RUN CGO_ENABLED=0 go build -o bin/finsplitter cmd/api/main.go
+ARG GIT_COMMIT
+ARG GIT_BUILD_TAG
+ARG BUILD_TIME
+
+RUN CGO_ENABLED=0 go build \ 
+    -ldflags "-X main.BuildCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME} -X main.BuildTag=${GIT_BUILD_TAG}" \
+    -o bin/finsplitter cmd/api/main.go
 
 # Execution stage
-FROM gcr.io/distroless/base-debian10 AS production
+FROM gcr.io/distroless/static-debian12:nonroot AS production
 
 # Copy the built binary
 COPY --from=builder /app/bin/finsplitter /

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ include .env
 
 NAME=finsplitter
 VERSION=prod
+GIT_BUILD_TAG=localtag
+GIT_COMMIT=$(shell git rev-parse HEAD)
+BUILD_TIME=$(shell date -u +%Y-%m-%dT%H:%M:%S%Z)
 
 start-infra:
 	@echo "==> Running infra containers"
@@ -23,7 +26,10 @@ stop-dev: stop-infra
 
 build:
 	@echo "==> Building Docker API image"
-	@docker build --target production --rm --compress -t ${NAME}:${VERSION} .
+	@docker build --build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg GIT_BUILD_TAG=$(GIT_BUILD_TAG) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) \
+		--target production --rm --compress -t ${NAME}:${VERSION} .
 
 clean:
 	@echo "==> Deleting Docker image"


### PR DESCRIPTION
Injeta informações a respeito do build em tempo de compilação. Essas informações são usadas no logger para ajudar em depurações.