### PR TITLE
feat: isolate PR labeler into separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,9 @@ jobs:
     pr-labeler:
         name: Label Pull Request
         if: github.event_name == 'pull_request'
-        uses: ./.github/workflows/release-drafter.yml
-        with:
-            labeler-only: true
+        uses: ./.github/workflows/pr-labeler.yml
         permissions:
-            contents: write
+            contents: read
             pull-requests: write
 
     release-drafter:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    auto_label_pr:
+        name: Auto Label PR
+        runs-on: ubuntu-latest
+        steps:
+            - uses: release-drafter/release-drafter/autolabeler@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,30 +2,14 @@ name: Release Drafter
 
 on:
     workflow_call:
-        inputs:
-            labeler-only:
-                description: "Run in labeler-only mode (autolabel PRs without drafting release)"
-                required: false
-                default: false
-                type: boolean
 
 permissions:
     contents: write
     pull-requests: write
 
 jobs:
-    auto_label_pr:
-        name: Auto Label PR
-        if: ${{ inputs.labeler-only }}
-        runs-on: ubuntu-latest
-        steps:
-            - uses: release-drafter/release-drafter/autolabeler@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     update_release_draft:
         name: Update Release Draft
-        if: ${{ !inputs.labeler-only }}
         runs-on: ubuntu-latest
         steps:
             - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1


### PR DESCRIPTION
## Summary
- Extract `auto_label_pr` job from `release-drafter.yml` into a new standalone `pr-labeler.yml` workflow
- Remove `labeler-only` input and conditional logic from `release-drafter.yml`
- Update `ci.yml` to reference the new `pr-labeler.yml` workflow

## Why
- Single responsibility: each workflow handles one concern
- Easier to trigger/maintain labeler and drafter independently
- Cleaner reusable workflow interfaces (no boolean flag gating)

## Changes
| File | Action |
|------|--------|
| `.github/workflows/pr-labeler.yml` | **Created** - standalone autolabeler workflow |
| `.github/workflows/release-drafter.yml` | **Simplified** - removed labeler job + input |
| `.github/workflows/ci.yml` | **Updated** - `pr-labeler` job points to new workflow |
| `.github/release-drafter.yml` | **No change** - shared config |