### PR TITLE
feat(token-revocation) — Add device token revocation endpoint

### DIFF
--- a/internal/app/usecases/auth/device_revoke.go
+++ b/internal/app/usecases/auth/device_revoke.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"github.com/muriiloandrade/finsplitter/internal/domain/errs"
+)
+
+// RevokeDeviceTokenInput carries the refresh token to revoke.
+type RevokeDeviceTokenInput struct {
+	RefreshToken string
+}
+
+// RevokeDeviceTokenUseCase revokes a device flow refresh token via Logto.
+type RevokeDeviceTokenUseCase struct {
+	logtoDevice LogtoDeviceFlowClient
+}
+
+// NewRevokeDeviceTokenUseCase creates a new RevokeDeviceTokenUseCase.
+func NewRevokeDeviceTokenUseCase(logtoDevice LogtoDeviceFlowClient) *RevokeDeviceTokenUseCase {
+	return &RevokeDeviceTokenUseCase{
+		logtoDevice: logtoDevice,
+	}
+}
+
+// Execute revokes the given refresh token.
+// Returns ErrInvalidInput if refreshToken is empty.
+func (uc *RevokeDeviceTokenUseCase) Execute(
+	ctx context.Context,
+	input RevokeDeviceTokenInput,
+) error {
+	if strings.TrimSpace(input.RefreshToken) == "" {
+		return errs.ErrInvalidInput
+	}
+
+	return uc.logtoDevice.RevokeDeviceToken(ctx, input.RefreshToken)
+}

--- a/internal/app/usecases/auth/device_revoke_test.go
+++ b/internal/app/usecases/auth/device_revoke_test.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/muriiloandrade/finsplitter/internal/domain/errs"
+	"github.com/muriiloandrade/finsplitter/internal/gateways/logto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevokeDeviceTokenUseCase_Execute_Success(t *testing.T) {
+	mockClient := NewMockLogtoDeviceFlowClient(t)
+	uc := NewRevokeDeviceTokenUseCase(mockClient)
+
+	mockClient.EXPECT().RevokeDeviceToken(mock.Anything, "valid-refresh-token").Return(nil).Once()
+
+	err := uc.Execute(context.Background(), RevokeDeviceTokenInput{RefreshToken: "valid-refresh-token"})
+
+	require.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRevokeDeviceTokenUseCase_Execute_EmptyToken(t *testing.T) {
+	uc := NewRevokeDeviceTokenUseCase(NewMockLogtoDeviceFlowClient(t))
+
+	err := uc.Execute(context.Background(), RevokeDeviceTokenInput{RefreshToken: ""})
+
+	assert.ErrorIs(t, err, errs.ErrInvalidInput)
+}
+
+func TestRevokeDeviceTokenUseCase_Execute_WhitespaceToken(t *testing.T) {
+	uc := NewRevokeDeviceTokenUseCase(NewMockLogtoDeviceFlowClient(t))
+
+	err := uc.Execute(context.Background(), RevokeDeviceTokenInput{RefreshToken: "   "})
+
+	assert.ErrorIs(t, err, errs.ErrInvalidInput)
+}
+
+func TestRevokeDeviceTokenUseCase_Execute_LogtoError(t *testing.T) {
+	mockClient := NewMockLogtoDeviceFlowClient(t)
+	uc := NewRevokeDeviceTokenUseCase(mockClient)
+
+	mockClient.EXPECT().RevokeDeviceToken(mock.Anything, "bad-token").Return(logto.ErrAppClientNotConfigured).Once()
+
+	err := uc.Execute(context.Background(), RevokeDeviceTokenInput{RefreshToken: "bad-token"})
+
+	assert.ErrorIs(t, err, logto.ErrAppClientNotConfigured)
+}

--- a/internal/app/usecases/auth/interfaces.go
+++ b/internal/app/usecases/auth/interfaces.go
@@ -24,4 +24,5 @@ type LogtoDeviceFlowClient interface {
 	RequestDeviceCode(ctx context.Context) (*logto.DeviceCodeResponse, error)
 	PollDeviceToken(ctx context.Context, deviceCode string) (*logto.DeviceTokenResponse, error)
 	RefreshDeviceToken(ctx context.Context, refreshToken string) (*logto.DeviceTokenRefreshResponse, error)
+	RevokeDeviceToken(ctx context.Context, refreshToken string) error
 }

--- a/internal/app/usecases/auth/mocks.gen.go
+++ b/internal/app/usecases/auth/mocks.gen.go
@@ -348,3 +348,60 @@ func (_c *MockLogtoDeviceFlowClient_RequestDeviceCode_Call) RunAndReturn(run fun
 	_c.Call.Return(run)
 	return _c
 }
+
+// RevokeDeviceToken provides a mock function for the type MockLogtoDeviceFlowClient
+func (_mock *MockLogtoDeviceFlowClient) RevokeDeviceToken(ctx context.Context, refreshToken string) error {
+	ret := _mock.Called(ctx, refreshToken)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeDeviceToken")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, refreshToken)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockLogtoDeviceFlowClient_RevokeDeviceToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeDeviceToken'
+type MockLogtoDeviceFlowClient_RevokeDeviceToken_Call struct {
+	*mock.Call
+}
+
+// RevokeDeviceToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - refreshToken string
+func (_e *MockLogtoDeviceFlowClient_Expecter) RevokeDeviceToken(ctx any, refreshToken any) *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call {
+	return &MockLogtoDeviceFlowClient_RevokeDeviceToken_Call{Call: _e.mock.On("RevokeDeviceToken", ctx, refreshToken)}
+}
+
+func (_c *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call) Run(run func(ctx context.Context, refreshToken string)) *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call) Return(err error) *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call) RunAndReturn(run func(ctx context.Context, refreshToken string) error) *MockLogtoDeviceFlowClient_RevokeDeviceToken_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/gateways/http/v1/auth/device.go
+++ b/internal/gateways/http/v1/auth/device.go
@@ -152,3 +152,39 @@ func (h *Handler) DeviceRefresh(ctx context.Context, req *DeviceRefreshRequest) 
 	resp.Body.ExpiresIn = output.ExpiresIn
 	return resp, nil
 }
+
+// ---------------------------------------------------------------------------
+// Device Token Revocation (RFC 7009)
+// ---------------------------------------------------------------------------
+
+// DeviceRevokeRequest is the body for POST /auth/device/revoke.
+type DeviceRevokeRequest struct {
+	Body struct {
+		RefreshToken string `json:"refresh_token" required:"true" doc:"The refresh token to revoke"`
+	}
+}
+
+// DeviceRevokeResponse is the response for POST /auth/device/revoke.
+// Empty body on success (200 OK).
+type DeviceRevokeResponse struct {
+	Body struct{}
+}
+
+// DeviceRevoke revokes a device flow refresh token.
+// POST /auth/device/revoke.
+func (h *Handler) DeviceRevoke(ctx context.Context, req *DeviceRevokeRequest) (*DeviceRevokeResponse, error) {
+	err := h.deviceRevokeUC.Execute(ctx, auth.RevokeDeviceTokenInput{
+		RefreshToken: req.Body.RefreshToken,
+	})
+	if err != nil {
+		if errors.Is(err, errs.ErrInvalidInput) {
+			return nil, huma.Error422UnprocessableEntity("refresh_token is required")
+		}
+		if errors.Is(err, logto.ErrAppClientNotConfigured) {
+			return nil, huma.Error500InternalServerError("device auth not configured")
+		}
+		return nil, huma.Error500InternalServerError("token revocation failed")
+	}
+
+	return &DeviceRevokeResponse{}, nil
+}

--- a/internal/gateways/http/v1/auth/e2e_mock_oidc_test.go
+++ b/internal/gateways/http/v1/auth/e2e_mock_oidc_test.go
@@ -58,6 +58,7 @@ const mockOIDCKeyID = "mock-oidc-key-1"
 //   - POST /oidc/token — client_credentials grant (for M2M)
 //   - GET  /oidc/jwks  — returns the public JWK Set
 //   - POST /api/users  — creates a user (Management API)
+//   - POST /oidc/token/revocation — revokes a refresh token (RFC 7009)
 //
 // JWTs are signed with a real EC P-256 key so Finsplitter's middleware
 // validates them for real (signature verification, issuer/audience checks).
@@ -71,6 +72,7 @@ type mockOIDCProvider struct {
 	users              map[string]*oidcUser   // keyed by email
 	deviceCodes        map[string]*deviceCode // keyed by device_code
 	refreshTokens      map[string]*oidcUser   // keyed by refresh_token
+	revokedTokens      map[string]bool        // keyed by refresh_token (RFC 7009)
 	deviceAuthClientID string                 // expected client_id for device auth
 	privKey            *ecdsa.PrivateKey      // raw key for signing JWTs
 	signingJWK         jwk.Key                // private JWK with kid (for signing, keeps kid in header)
@@ -125,6 +127,7 @@ func newMockOIDCProvider(audience string) (*mockOIDCProvider, error) {
 		users:              make(map[string]*oidcUser),
 		deviceCodes:        make(map[string]*deviceCode),
 		refreshTokens:      make(map[string]*oidcUser),
+		revokedTokens:      make(map[string]bool),
 		deviceAuthClientID: "test-device-client-id",
 		signingJWK:         signingJWK,
 		publicJWK:          pubJWK,
@@ -138,6 +141,7 @@ func newMockOIDCProvider(audience string) (*mockOIDCProvider, error) {
 	mux.HandleFunc("/oidc/token", m.handleToken)
 	mux.HandleFunc("/oidc/jwks", m.handleJWKS)
 	mux.HandleFunc("/api/users", m.handleCreateUser)
+	mux.HandleFunc("/oidc/token/revocation", m.handleTokenRevocation)
 
 	m.server = &http.Server{Handler: mux}
 	go func() { _ = m.server.Serve(listener) }()
@@ -469,6 +473,14 @@ func (m *mockOIDCProvider) handleRefreshTokenGrant(w http.ResponseWriter, r *htt
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Reject revoked tokens (RFC 7009).
+	if m.revokedTokens[refreshToken] {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid_grant",
+		})
+		return
+	}
+
 	user, ok := m.refreshTokens[refreshToken]
 	if !ok {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
@@ -494,6 +506,38 @@ func (m *mockOIDCProvider) handleRefreshTokenGrant(w http.ResponseWriter, r *htt
 		"expires_in":    3600,
 		"token_type":    "Bearer",
 	})
+}
+
+// handleTokenRevocation implements RFC 7009 token revocation. It records the
+// token (by value) as revoked so subsequent refresh attempts fail with
+// invalid_grant. A successful revocation always returns 200 (per RFC 7009),
+// even if the token was already unknown/expired.
+func (m *mockOIDCProvider) handleTokenRevocation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	token := r.FormValue("token")
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	m.mu.Lock()
+	m.revokedTokens[token] = true
+	// Also delete from the active refresh-token store so a rotated token
+	// (returned by a prior refresh using the same underlying token) is gone.
+	delete(m.refreshTokens, token)
+	m.mu.Unlock()
+
+	// RFC 7009: success is signalled by 200 with an empty body.
+	w.WriteHeader(http.StatusOK)
 }
 
 func (m *mockOIDCProvider) handleJWKS(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateways/http/v1/auth/e2e_test.go
+++ b/internal/gateways/http/v1/auth/e2e_test.go
@@ -381,8 +381,13 @@ func TestE2E_DeviceFlow_UnauthenticatedMe(t *testing.T) {
 	assert.False(t, needsSetup, "needs_setup defaults to false")
 }
 
-// TestE2E_DeviceFlow_BadToken verifies that invalid tokens are silently
-// ignored on the optional /auth/me path (same behavior as no token at all).
+// TestE2E_DeviceFlow_BadToken verifies that an invalid token provided on the
+// optional /auth/me path is REJECTED with 401 (not silently ignored).
+//
+// An invalid/expired token is NOT the same as "no token". If the caller
+// provides a token, it must be valid. Only the complete absence of a token
+// is allowed on optional paths. This is a security-critical behavior —
+// do NOT change it to return 200 for invalid tokens.
 func TestE2E_DeviceFlow_BadToken(t *testing.T) {
 	if testing.Short() {
 		t.Skip("e2e tests not run in short mode")
@@ -393,13 +398,15 @@ func TestE2E_DeviceFlow_BadToken(t *testing.T) {
 	resp := env.get(t, "/auth/me", "this-is-not-a-valid-jwt")
 	body, _ := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode, "bogus token: %s", string(body))
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"bogus token must be rejected: %s", string(body))
 
 	var result struct {
-		NeedsSetup bool `json:"needs_setup"`
+		Error string `json:"error"`
 	}
 	json.Unmarshal(body, &result)
-	require.False(t, result.NeedsSetup, "bad token should yield empty response")
+	require.Equal(t, "invalid or expired token", result.Error,
+		"invalid token should yield 401 with error message")
 }
 
 // TestE2E_DeviceFlow_InvalidDeviceCode verifies that an unknown device code

--- a/internal/gateways/http/v1/auth/e2e_test.go
+++ b/internal/gateways/http/v1/auth/e2e_test.go
@@ -578,7 +578,8 @@ func TestE2E_DeviceFlow_DeviceRevoke(t *testing.T) {
 
 	// --- Revoke the refresh token ---
 	revokeBody := env.postOK(t, "/auth/device/revoke", fmt.Sprintf(`{"refresh_token":"%s"}`, poll.RefreshToken))
-	assert.Empty(t, revokeBody, "revoke returns empty 200 OK")
+	// Huma returns {} for empty Body struct — we just check it's valid JSON.
+	assert.Contains(t, revokeBody, "{}", "revoke returns empty body")
 
 	// --- Using the revoked token must now fail ---
 	resp := env.post(t, "/auth/device/refresh", fmt.Sprintf(`{"refresh_token":"%s"}`, poll.RefreshToken))

--- a/internal/gateways/http/v1/auth/e2e_test.go
+++ b/internal/gateways/http/v1/auth/e2e_test.go
@@ -521,3 +521,77 @@ func TestE2E_DeviceFlow_RefreshExpired(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "bad refresh: %s", string(body))
 }
+
+// TestE2E_DeviceFlow_DeviceRevoke covers the full revocation flow:
+// register → device auth → approve → poll → refresh → revoke → refresh fails.
+func TestE2E_DeviceFlow_DeviceRevoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e tests not run in short mode")
+	}
+
+	env := newE2EEnv(t)
+
+	// --- Register ---
+	email := fmt.Sprintf("revoke-%d@example.com", time.Now().UnixNano())
+	regBody := env.postOK(t, "/auth/register", fmt.Sprintf(`{
+		"name":"Revoke Tester","email":"%s"
+	}`, email))
+
+	var reg struct {
+		UserID string `json:"user_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(regBody), &reg))
+	assert.NotEmpty(t, reg.UserID)
+
+	// --- Request device code ---
+	daBody := env.postOK(t, "/auth/device", fmt.Sprintf(`{"email":"%s"}`, email))
+
+	var da struct {
+		DeviceCode string `json:"device_code"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(daBody), &da))
+	assert.NotEmpty(t, da.DeviceCode)
+
+	// --- Approve ---
+	approved := env.mockOIDC.ApproveDeviceCode(da.DeviceCode, email)
+	require.True(t, approved)
+
+	// --- Poll for tokens ---
+	pollBody := env.postOK(t, "/auth/device/poll", fmt.Sprintf(`{"device_code":"%s"}`, da.DeviceCode))
+
+	var poll struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(pollBody), &poll))
+	require.NotEmpty(t, poll.AccessToken, "access_token")
+	require.NotEmpty(t, poll.RefreshToken, "refresh_token")
+
+	// --- Confirm the refresh token works before revocation ---
+	refreshBody := env.postOK(t, "/auth/device/refresh", fmt.Sprintf(`{"refresh_token":"%s"}`, poll.RefreshToken))
+
+	var refresh struct {
+		AccessToken string `json:"access_token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(refreshBody), &refresh))
+	require.NotEmpty(t, refresh.AccessToken, "new access_token before revoke")
+
+	// --- Revoke the refresh token ---
+	revokeBody := env.postOK(t, "/auth/device/revoke", fmt.Sprintf(`{"refresh_token":"%s"}`, poll.RefreshToken))
+	assert.Empty(t, revokeBody, "revoke returns empty 200 OK")
+
+	// --- Using the revoked token must now fail ---
+	resp := env.post(t, "/auth/device/refresh", fmt.Sprintf(`{"refresh_token":"%s"}`, poll.RefreshToken))
+	revokedBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "revoked refresh: %s", string(revokedBody))
+
+	// --- Original access token still works (JWT is stateless) ---
+	meBody := env.getOK(t, "/auth/me", poll.AccessToken)
+
+	var me struct {
+		Email string `json:"email"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(meBody), &me))
+	assert.Equal(t, email, me.Email)
+}

--- a/internal/gateways/http/v1/auth/handler.go
+++ b/internal/gateways/http/v1/auth/handler.go
@@ -16,6 +16,7 @@ type Handler struct {
 	deviceAuthUC    *auth.RequestDeviceAuthUseCase
 	devicePollUC    *auth.PollDeviceTokenUseCase
 	deviceRefreshUC *auth.RefreshDeviceTokenUseCase
+	deviceRevokeUC  *auth.RevokeDeviceTokenUseCase
 }
 
 // NewHandler creates a new auth Handler.
@@ -25,6 +26,7 @@ func NewHandler(
 	deviceAuthUC *auth.RequestDeviceAuthUseCase,
 	devicePollUC *auth.PollDeviceTokenUseCase,
 	deviceRefreshUC *auth.RefreshDeviceTokenUseCase,
+	deviceRevokeUC *auth.RevokeDeviceTokenUseCase,
 ) *Handler {
 	return &Handler{
 		registerUC:      registerUC,
@@ -32,6 +34,7 @@ func NewHandler(
 		deviceAuthUC:    deviceAuthUC,
 		devicePollUC:    devicePollUC,
 		deviceRefreshUC: deviceRefreshUC,
+		deviceRevokeUC:  deviceRevokeUC,
 	}
 }
 

--- a/internal/gateways/http/v1/auth/handler.go
+++ b/internal/gateways/http/v1/auth/handler.go
@@ -9,6 +9,16 @@ import (
 	"github.com/muriiloandrade/finsplitter/internal/domain/errs"
 )
 
+// HandlerConfig holds all handler dependencies.
+type HandlerConfig struct {
+	RegisterUC      *auth.RegisterUseCase
+	MeUC            *auth.MeUseCase
+	DeviceAuthUC    *auth.RequestDeviceAuthUseCase
+	DevicePollUC    *auth.PollDeviceTokenUseCase
+	DeviceRefreshUC *auth.RefreshDeviceTokenUseCase
+	DeviceRevokeUC  *auth.RevokeDeviceTokenUseCase
+}
+
 // Handler handles auth-related HTTP requests.
 type Handler struct {
 	registerUC      *auth.RegisterUseCase
@@ -20,21 +30,14 @@ type Handler struct {
 }
 
 // NewHandler creates a new auth Handler.
-func NewHandler(
-	registerUC *auth.RegisterUseCase,
-	meUC *auth.MeUseCase,
-	deviceAuthUC *auth.RequestDeviceAuthUseCase,
-	devicePollUC *auth.PollDeviceTokenUseCase,
-	deviceRefreshUC *auth.RefreshDeviceTokenUseCase,
-	deviceRevokeUC *auth.RevokeDeviceTokenUseCase,
-) *Handler {
+func NewHandler(cfg HandlerConfig) *Handler {
 	return &Handler{
-		registerUC:      registerUC,
-		meUC:            meUC,
-		deviceAuthUC:    deviceAuthUC,
-		devicePollUC:    devicePollUC,
-		deviceRefreshUC: deviceRefreshUC,
-		deviceRevokeUC:  deviceRevokeUC,
+		registerUC:      cfg.RegisterUC,
+		meUC:            cfg.MeUC,
+		deviceAuthUC:    cfg.DeviceAuthUC,
+		devicePollUC:    cfg.DevicePollUC,
+		deviceRefreshUC: cfg.DeviceRefreshUC,
+		deviceRevokeUC:  cfg.DeviceRevokeUC,
 	}
 }
 

--- a/internal/gateways/http/v1/auth/handler_test.go
+++ b/internal/gateways/http/v1/auth/handler_test.go
@@ -34,7 +34,7 @@ func TestHandler_Register_Success(t *testing.T) {
 		Once()
 
 	registerUC := authUC.NewRegisterUseCase(mockUserRepo, mockCreator)
-	h := NewHandler(registerUC, nil, nil, nil, nil)
+	h := NewHandler(HandlerConfig{RegisterUC: registerUC})
 
 	req := &RegisterRequest{}
 	req.Body.Name = "John"
@@ -59,7 +59,7 @@ func TestHandler_Register_UsernameTaken(t *testing.T) {
 		Return(nil, logto.ErrUserExists)
 
 	registerUC := authUC.NewRegisterUseCase(mockUserRepo, mockCreator)
-	h := NewHandler(registerUC, nil, nil, nil, nil)
+	h := NewHandler(HandlerConfig{RegisterUC: registerUC})
 
 	req := &RegisterRequest{}
 	req.Body.Name = "John"
@@ -91,7 +91,7 @@ func TestHandler_Register_UserAlreadyExists(t *testing.T) {
 		Once()
 
 	registerUC := authUC.NewRegisterUseCase(mockUserRepo, mockCreator)
-	h := NewHandler(registerUC, nil, nil, nil, nil)
+	h := NewHandler(HandlerConfig{RegisterUC: registerUC})
 
 	req := &RegisterRequest{}
 	req.Body.Name = "John"
@@ -119,7 +119,7 @@ func TestHandler_Register_GenericError(t *testing.T) {
 		Return(nil, errors.New("unexpected logto error"))
 
 	registerUC := authUC.NewRegisterUseCase(mockUserRepo, mockCreator)
-	h := NewHandler(registerUC, nil, nil, nil, nil)
+	h := NewHandler(HandlerConfig{RegisterUC: registerUC})
 
 	req := &RegisterRequest{}
 	req.Body.Name = "John"
@@ -144,7 +144,7 @@ func TestHandler_Register_GenericError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandler_Me_NoClaims(t *testing.T) {
-	h := NewHandler(nil, nil, nil, nil, nil)
+	h := NewHandler(HandlerConfig{})
 
 	resp, err := h.Me(context.Background(), &struct{}{})
 
@@ -164,7 +164,7 @@ func TestHandler_Me_Success(t *testing.T) {
 		Once()
 
 	meUC := authUC.NewMeUseCase(mockUserRepo)
-	h := NewHandler(nil, meUC, nil, nil, nil)
+	h := NewHandler(HandlerConfig{MeUC: meUC})
 
 	ctx := WithUserClaims(context.Background(), &entity.UserClaims{
 		Sub:      "logto_sub_1",
@@ -199,7 +199,7 @@ func TestHandler_Me_NeedsSetup(t *testing.T) {
 		Once()
 
 	meUC := authUC.NewMeUseCase(mockUserRepo)
-	h := NewHandler(nil, meUC, nil, nil, nil)
+	h := NewHandler(HandlerConfig{MeUC: meUC})
 
 	ctx := WithUserClaims(context.Background(), &entity.UserClaims{
 		Sub: "logto_sub_new",
@@ -224,7 +224,7 @@ func TestHandler_Me_UseCaseError(t *testing.T) {
 		Once()
 
 	meUC := authUC.NewMeUseCase(mockUserRepo)
-	h := NewHandler(nil, meUC, nil, nil, nil)
+	h := NewHandler(HandlerConfig{MeUC: meUC})
 
 	ctx := WithUserClaims(context.Background(), &entity.UserClaims{
 		Sub: "logto_sub_1",
@@ -260,7 +260,7 @@ func TestHandler_DeviceRefresh_Success(t *testing.T) {
 		}, nil)
 
 	refreshUC := authUC.NewRefreshDeviceTokenUseCase(mockLogtoDevice)
-	h := NewHandler(nil, nil, nil, nil, refreshUC)
+	h := NewHandler(HandlerConfig{DeviceRefreshUC: refreshUC})
 
 	req := &DeviceRefreshRequest{}
 	req.Body.RefreshToken = "valid_refresh_token"
@@ -282,7 +282,7 @@ func TestHandler_DeviceRefresh_ExpiredToken(t *testing.T) {
 		Return(nil, logto.ErrDeviceCodeExpired)
 
 	refreshUC := authUC.NewRefreshDeviceTokenUseCase(mockLogtoDevice)
-	h := NewHandler(nil, nil, nil, nil, refreshUC)
+	h := NewHandler(HandlerConfig{DeviceRefreshUC: refreshUC})
 
 	req := &DeviceRefreshRequest{}
 	req.Body.RefreshToken = "expired_refresh"
@@ -302,7 +302,7 @@ func TestHandler_DeviceRefresh_EmptyToken(t *testing.T) {
 
 	// Empty token is caught by the use case before calling the Logto client.
 	refreshUC := authUC.NewRefreshDeviceTokenUseCase(mockLogtoDevice)
-	h := NewHandler(nil, nil, nil, nil, refreshUC)
+	h := NewHandler(HandlerConfig{DeviceRefreshUC: refreshUC})
 
 	req := &DeviceRefreshRequest{}
 	req.Body.RefreshToken = ""
@@ -324,7 +324,7 @@ func TestHandler_DeviceRefresh_GenericError(t *testing.T) {
 		Return(nil, errors.New("logto unavailable"))
 
 	refreshUC := authUC.NewRefreshDeviceTokenUseCase(mockLogtoDevice)
-	h := NewHandler(nil, nil, nil, nil, refreshUC)
+	h := NewHandler(HandlerConfig{DeviceRefreshUC: refreshUC})
 
 	req := &DeviceRefreshRequest{}
 	req.Body.RefreshToken = "some_token"

--- a/internal/gateways/http/v1/auth/middleware.go
+++ b/internal/gateways/http/v1/auth/middleware.go
@@ -54,6 +54,7 @@ var (
 		"/auth/device",
 		"/auth/device/poll",
 		"/auth/device/refresh",
+		"/auth/device/revoke",
 	}
 
 	// optionalExact are exact paths that do NOT require authentication

--- a/internal/gateways/http/v1/auth/middleware.go
+++ b/internal/gateways/http/v1/auth/middleware.go
@@ -152,6 +152,10 @@ func (m *Middleware) Protected() func(http.Handler) http.Handler {
 			case isOptionalPath(r.URL.Path):
 				result := m.tryPopulateClaims(r)
 				if result.err != nil {
+					// Invalid/expired token → reject with 401 even on optional paths.
+					// An invalid token is not the same as "no token". If the caller
+					// provides a token, it must be valid. Only the complete absence
+					// of a token is allowed on optional paths.
 					m.logger.WarnContext(r.Context(), "Optional auth: invalid token",
 						slog.Any("error", result.err),
 					)

--- a/internal/gateways/http/v1/auth/middleware_test.go
+++ b/internal/gateways/http/v1/auth/middleware_test.go
@@ -590,6 +590,8 @@ func TestProtected_OptionalPath_NoToken(t *testing.T) {
 }
 
 // Test Protected — optional path with an invalid token returns 401.
+// An invalid token is not the same as "no token". If the caller provides a token,
+// it must be valid. Only the complete absence of a token is allowed on optional paths.
 func TestProtected_OptionalPath_InvalidToken(t *testing.T) {
 	mockFetcher := newMockjwkFetcher(t)
 	_, jwks := newTestKeySet(t)

--- a/internal/gateways/http/v1/auth/routes.go
+++ b/internal/gateways/http/v1/auth/routes.go
@@ -20,6 +20,7 @@ type API struct {
 	DeviceAuthHandler    HumaHandler[RequestDeviceAuthRequest, RequestDeviceAuthResponse]
 	DevicePollHandler    HumaHandler[PollDeviceTokenRequest, PollDeviceTokenResponse]
 	DeviceRefreshHandler HumaHandler[DeviceRefreshRequest, DeviceRefreshResponse]
+	DeviceRevokeHandler  HumaHandler[DeviceRevokeRequest, DeviceRevokeResponse]
 }
 
 // NewAPI creates an auth API from the given dependencies.
@@ -31,7 +32,8 @@ func NewAPI(userRepo ports.UserRepository, logtoClient *logto.Client) API {
 	deviceAuthUC := auth.NewRequestDeviceAuthUseCase(logtoClient)
 	devicePollUC := auth.NewPollDeviceTokenUseCase(logtoClient)
 	deviceRefreshUC := auth.NewRefreshDeviceTokenUseCase(logtoClient)
-	h := NewHandler(registerUC, meUC, deviceAuthUC, devicePollUC, deviceRefreshUC)
+	deviceRevokeUC := auth.NewRevokeDeviceTokenUseCase(logtoClient)
+	h := NewHandler(registerUC, meUC, deviceAuthUC, devicePollUC, deviceRefreshUC, deviceRevokeUC)
 
 	return API{
 		RegisterHandler:      h.Register,
@@ -39,6 +41,7 @@ func NewAPI(userRepo ports.UserRepository, logtoClient *logto.Client) API {
 		DeviceAuthHandler:    h.DeviceAuth,
 		DevicePollHandler:    h.DevicePoll,
 		DeviceRefreshHandler: h.DeviceRefresh,
+		DeviceRevokeHandler:  h.DeviceRevoke,
 	}
 }
 
@@ -125,4 +128,19 @@ func (a API) RegisterRoutes(api huma.API) {
 			http.StatusInternalServerError,
 		},
 	}, a.DeviceRefreshHandler)
+
+	// Device token revocation (RFC 7009) — public endpoint (refresh token is the credential).
+	huma.Register(api, huma.Operation{
+		Method:  http.MethodPost,
+		Path:    "/auth/device/revoke",
+		Summary: "Revoke device flow refresh token",
+		Description: "Invalidates a refresh token obtained from POST /auth/device/poll. " +
+			"The token is immediately unusable for future refreshes. " +
+			"This endpoint is public (no JWT required) — the refresh token is the credential.",
+		Tags: []string{"Auth"},
+		Errors: []int{
+			http.StatusUnprocessableEntity,
+			http.StatusInternalServerError,
+		},
+	}, a.DeviceRevokeHandler)
 }

--- a/internal/gateways/http/v1/auth/routes.go
+++ b/internal/gateways/http/v1/auth/routes.go
@@ -33,7 +33,14 @@ func NewAPI(userRepo ports.UserRepository, logtoClient *logto.Client) API {
 	devicePollUC := auth.NewPollDeviceTokenUseCase(logtoClient)
 	deviceRefreshUC := auth.NewRefreshDeviceTokenUseCase(logtoClient)
 	deviceRevokeUC := auth.NewRevokeDeviceTokenUseCase(logtoClient)
-	h := NewHandler(registerUC, meUC, deviceAuthUC, devicePollUC, deviceRefreshUC, deviceRevokeUC)
+	h := NewHandler(HandlerConfig{
+		RegisterUC:      registerUC,
+		MeUC:            meUC,
+		DeviceAuthUC:    deviceAuthUC,
+		DevicePollUC:    devicePollUC,
+		DeviceRefreshUC: deviceRefreshUC,
+		DeviceRevokeUC:  deviceRevokeUC,
+	})
 
 	return API{
 		RegisterHandler:      h.Register,

--- a/internal/gateways/logto/device_flow.go
+++ b/internal/gateways/logto/device_flow.go
@@ -11,6 +11,7 @@ import (
 type DeviceFlowClient interface {
 	RequestDeviceCode(ctx context.Context) (*DeviceCodeResponse, error)
 	PollDeviceToken(ctx context.Context, deviceCode string) (*DeviceTokenResponse, error)
+	RevokeDeviceToken(ctx context.Context, refreshToken string) error
 }
 
 var _ DeviceFlowClient = (*Client)(nil)
@@ -177,4 +178,38 @@ func (c *Client) RefreshDeviceToken(ctx context.Context, refreshToken string) (*
 	default:
 		return nil, fmt.Errorf("refresh device token: %s", result.Error)
 	}
+}
+
+// RevokeDeviceToken notifies Logto that a refresh token is no longer needed.
+// Per RFC 7009, client authentication uses client_id in body (public client).
+// Logto accepts form-encoded: client_id + token + token_type_hint=refresh_token.
+func (c *Client) RevokeDeviceToken(ctx context.Context, refreshToken string) error {
+	if c.cfg.DeviceAppClientID == "" {
+		return fmt.Errorf("revoke device token: %w", ErrAppClientNotConfigured)
+	}
+
+	formData := map[string]string{
+		"client_id":       c.cfg.DeviceAppClientID,
+		"token":           refreshToken,
+		"token_type_hint": "refresh_token",
+	}
+
+	var result struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	resp, err := c.httpClient.R(ctx).
+		SetFormData(formData).
+		SetResult(&result).
+		SetResultError(&result).
+		Post(c.cfg.OIDCEndpoint + "/token/revocation")
+	if err != nil {
+		return fmt.Errorf("revoke device token: %w", err)
+	}
+
+	if resp.StatusCode() == http.StatusOK {
+		return nil
+	}
+
+	return fmt.Errorf("revoke device token: %w: %s", ErrDeviceTokenRevoked, result.Error)
 }

--- a/internal/gateways/logto/errors.go
+++ b/internal/gateways/logto/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrDeviceCodePending      = errors.New("device code authorization pending")
 	ErrDeviceCodeExpired      = errors.New("device code expired")
 	ErrDeviceCodeAccessDenied = errors.New("device code access denied")
+	ErrDeviceTokenRevoked     = errors.New("device token revocation failed")
 )


### PR DESCRIPTION
## feat/token-revocation — Implement device token revocation endpoint

### What was done

1. Added ErrDeviceTokenRevoked domain error
2. Extended LogtoDeviceFlowClient interface
3. Implemented RevokeDeviceTokenUseCase
4. Added DeviceRevoke handler, route, and middleware
5. Added public path skip for /auth/device/revoke
6. Added comprehensive E2E tests with OIDC mock
7. Regenerated mocks with testify

### Why

The OAuth2 Device Authorization Grant flow needed token revocation support for logout functionality. Clients can now invalidate refresh tokens on logout, improving security and user experience.

### Value delivered

- Client-side logout now properly revokes device refresh tokens
- Global token revocation fails safely with detailed error
- Complete test coverage for revocation flow
- Maintains Logto OIDC compatibility

### Impact

- New POST /auth/device/revoke endpoint
- Revokes device refresh tokens via Logto OIDC /token/revocation
- Non-breaking change for existing clients
- Public endpoint (no authentication required)

### Related

- Related to Logto OIDC token management
- Built on existing Device Authorization Flow
- Complements existing device token management