### PR TITLE
fix(ci): enforce commitlint on pull request titles

### DIFF
--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -58,7 +58,7 @@ jobs:
             - name: Run Commitlint
               uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
               with:
-                  configFile: .github/commitlint.config.mjs
+                  configFile: commitlint.config.mjs
 
             - name: Run Gitleaks
               uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -50,6 +50,7 @@ jobs:
                   test -z "$(git status --porcelain -- '*mocks.gen.go')"
 
             - name: Check for TODOs in PR
+              if: github.event_name == 'pull_request'
               run: |
                   if git diff origin/${{ github.base_ref }}...HEAD | grep -i "TODO\|FIXME\|XXX"; then
                     echo "::warning::Found TODO/FIXME comments in PR"

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -60,6 +60,16 @@ jobs:
               with:
                   configFile: commitlint.config.mjs
 
+            # The squash-merge commit on main is named after the PR title and gets
+            # linted on push, so a bad title would break the pipeline after merge.
+            # Lint the title up front to catch it before merge. The title is passed
+            # via env (not inlined in the script) to avoid shell injection.
+            - name: Lint PR title
+              if: github.event_name == 'pull_request'
+              env:
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+              run: echo "$PR_TITLE" | npx --package=@commitlint/cli --package=@commitlint/config-conventional commitlint --config commitlint.config.mjs
+
             - name: Run Gitleaks
               uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
               env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-<!-- Context: dox/root | Priority: critical | Version: 2.1 | Updated: 2026-08-13 -->
+<!-- Context: dox/root | Priority: critical | Version: 2.2 | Updated: 2026-08-14 -->
 
 # DOX framework
 
@@ -55,6 +55,13 @@ make code-check      # format + lint (golangci-lint)
 make generate        # sqlc + mocks generators
 make new-migration name=create_table_foo
 ```
+
+## Commit Conventions
+
+- Conventional commits (lowercase type: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, ...) — enforced by lefthook locally and commitlint in CI
+- **PR titles must pass the same commitlint rules** — the squash-merge commit is named after the PR title and is linted on push to `main`; CI also lints the title on pull requests
+- Subject starts with a lowercase word (no sentence-case/uppercase acronyms at the start), header ≤ 100 chars, no trailing period
+- Config: `commitlint.config.mjs` (repo root)
 
 ## First Time Setup
 


### PR DESCRIPTION
## fix/ci-commitlint-config-path — commitlint enforcement for pull requests

### What was done

1. Fixed the commitlint config path in CI so the repo's `commitlint.config.mjs` is actually used — the previous `.github/...` path didn't exist and CI silently fell back to default conventional rules
2. Added a CI step that lints the pull request title with commitlint, catching titles that would break the pipeline after merge
3. Guarded the TODO/FIXME check so it only runs on pull requests (it silently failed on pushes to main)
4. Documented the commit conventions in the root AGENTS.md

### Why

Finsplitter merges with squash commits — the commit that lands on main is named after the PR title and is linted when pushed. A title that didn't follow the conventional commit rules broke the pipeline on main right after a merge. This change catches such titles before they land, instead of after.

### Value delivered

- The main pipeline stays green: bad PR titles are rejected before merge
- CI honors the repo's commitlint configuration (future rule changes take effect automatically)
- Clear, enforced commit conventions are documented in the repo

### Impact

- CI only — no runtime or API changes
- Pull requests with non-conventional titles will now fail the Prerequisites check with a clear commitlint error

### Related

- #235 — the merge that exposed this problem