### PR TITLE
chore: collapse maintenance and dependencies sections in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -57,6 +57,14 @@ change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 
+# Collapse high-noise categories (renovate/dependabot churn) on the release page.
+# Wraps each section body in <details><summary> so it starts collapsed.
+replacers:
+    - search: '/## 🧰 Maintenance\n\n([\s\S]*?)(?=\n## |$)/'
+      replace: "<details>\n<summary>🧰 Maintenance</summary>\n\n$1\n\n</details>"
+    - search: '/## 🛠️ Dependencies\n\n([\s\S]*?)(?=\n## |$)/'
+      replace: "<details>\n<summary>🛠️ Dependencies</summary>\n\n$1\n\n</details>"
+
 autolabeler:
     - label: "feature"
       title:


### PR DESCRIPTION
## chore/collapsible-release-sections — collapse noisy sections on the release page

### What was done

1. Configured the release notes drafter so the "🧰 Maintenance" and "🛠️ Dependencies" sections render as collapsible blocks that start collapsed.
2. All other sections (features, bug fixes, documentation, security, performance) continue to render expanded as before.

### Why

Dependency-automation pull requests (Renovate/Dependabot) can add dozens of entries to a single release. On the release page these drowned out the changes people actually read — features and fixes — so those sections now start folded away while remaining one click away.

### Value delivered

- Release pages lead with features and fixes instead of a wall of dependency bumps
- Maintenance and dependency details are still fully available, just tucked away
- No change to how releases are cut, tagged, or versioned

### Impact

- Affects only the rendered text of draft releases on GitHub
- No application code, endpoints, or behavior changes