### PR TITLE
fix: keep blank line after collapsed release sections

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -59,11 +59,15 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 
 # Collapse high-noise categories (renovate/dependabot churn) on the release page.
 # Wraps each section body in <details><summary> so it starts collapsed.
+# The trailing \n after </details> is required: the lookahead leaves the
+# section separator unconsumed, and without it the next heading (or
+# "## Contributors" when the collapsed section is last) ends up glued to
+# the HTML block and renders as raw text.
 replacers:
     - search: '/## 🧰 Maintenance\n\n([\s\S]*?)(?=\n## |$)/'
-      replace: "<details>\n<summary>🧰 Maintenance</summary>\n\n$1\n\n</details>"
+      replace: "<details>\n<summary>🧰 Maintenance</summary>\n\n$1\n\n</details>\n"
     - search: '/## 🛠️ Dependencies\n\n([\s\S]*?)(?=\n## |$)/'
-      replace: "<details>\n<summary>🛠️ Dependencies</summary>\n\n$1\n\n</details>"
+      replace: "<details>\n<summary>🛠️ Dependencies</summary>\n\n$1\n\n</details>\n"
 
 autolabeler:
     - label: "feature"


### PR DESCRIPTION
## chore/release-drafter-collapsible-sections — fix raw-text heading after collapsed release sections

### What was done

1. Fixed the release-notes collapsing configuration so the content that follows a collapsed section (the next section heading, or "Contributors" when a collapsed section is last) renders as proper markdown again instead of raw text.
2. The collapsible blocks now always end with a blank line before whatever comes after them.

### Why

The collapsing logic consumed the blank line that separates sections, gluing the closing tag of a collapsed block directly onto the next heading. GitHub then treated that heading as part of the HTML block and displayed it as literal text (most visibly the "## Contributors" header whenever the dependencies section was the last one in a release).

### Value delivered

- Release pages render correctly end to end: collapsed maintenance/dependencies blocks followed by properly formatted headings
- Verified against simulated release bodies covering both edge cases (collapsed section in the middle and at the end)

### Impact

- Affects only the rendered text of draft releases on GitHub
- No application code, endpoints, or behavior changes